### PR TITLE
fixing jbpmdev irc channel name

### DIFF
--- a/community/chat.adoc
+++ b/community/chat.adoc
@@ -26,7 +26,7 @@ Most of our project discussion take place on IRC, usually during European and Am
 
         *** *#droolsdev*
         *** *#guvnordev*
-        *** *#jbmdev*
+        *** *#jbpmdev*
 
 ==  Guidelines
 


### PR DESCRIPTION
Fixing the irc channel name for #jbpmdev team