### PR TITLE
added a page to adjust look and feel for selected artifacts download

### DIFF
--- a/_config/pom.yml
+++ b/_config/pom.yml
@@ -42,6 +42,16 @@ latestFinal:
     userGuideBook: https://www.gitbook.com/@nheron
     userGuidePDF: https://nheron.gitbooks.io/droolsonboarding/content/
 
+    droolsSnapZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.drools&a=drools-distribution&v=7.26.0-SNAPSHOT&e=zip
+    jbpmSnapZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.jbpm&a=jbpm-distribution&v=7.26.0-SNAPSHOT&e=zip&c=bin
+    businessCentralSnapWF: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie&a=business-central&v=7.26.0-SNAPSHOT&e=war&c=wildfly14
+    kieserverSnapEe7: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=7.26.0-SNAPSHOT&e=war&c=ee7
+    kieserverSnapEe8: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=7.26.0-SNAPSHOT&e=war&c=ee8
+    kieserverSnapWebc: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=7.26.0-SNAPSHOT&e=war&c=webc
+    kieserverSnapDistZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server-distribution&v=7.26.0-SNAPSHOT&e=zip
+    tomcatIntergrationSnap: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie&a=kie-tomcat-integration&v=7.26.0-SNAPSHOT&e=jar
+    updatesiteSnapZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.drools&a=org.drools.updatesite&v=7.26.0-SNAPSHOT&e=zip
+
 # latest.version can be equal to latestFinal.version
 latest:
     version: 7.25.0.Final

--- a/download/download.adoc
+++ b/download/download.adoc
@@ -119,7 +119,7 @@ For more info about the Drools Docker images see this http://blog.athico.com/201
 
 === Nightly Builds
 
-* Nightly SNAPSHOTS are available for download https://downloads.jboss.org/drools/release/snapshot/master/index.html[here].
+* Selected nightly SNAPSHOTS are available for download link:snapshots.html[here].
 
 === Eclipse update site
 

--- a/download/snapshots.html.haml
+++ b/download/snapshots.html.haml
@@ -1,0 +1,51 @@
+---
+description: Professional services for drools by Red Hat
+layout: normalBase
+title: Selected nightly Snapshots
+---
+
+%h1 #{page.title}
+
+:asciidoc
+
+  [.summaryParagraph]
+  On this page you can download selected binaries of nightly builds.
+
+-#.panel.panel-default
+-#  .panel-body
+-#    %iframe(src="https://www.redhat.com/forms/?config=droolsFromId" style="width: 100%; height: 700px; border: none;")
+
+:asciidoc
+
+  |===
+
+  |Name |Download
+
+  |*Drools distribution*
+  |#{site.pom.latestFinal.droolsSnapZip}[Drools-distribution ZIP]
+
+  |*Jbpm distribution*
+  |#{site.pom.latestFinal.jbpmSnapZip}[Jbpm-distribution-bin ZIP]
+
+  |*Business Central WAR*
+  |#{site.pom.latestFinal.businessCentralSnapWF}[Wildfly 14 WAR]
+
+  |*kie server ee7*
+  |#{site.pom.latestFinal.kieserverSnapEe7}[ee7 WAR]
+
+  |*kie server ee8*
+  |#{site.pom.latestFinal.kieserverSnapEe8}[ee8 WAR]
+
+  |*kie server webc*
+  |#{site.pom.latestFinal.kieserverSnapWebc}[webc WAR]
+
+  |*kie server distribution*
+  |#{site.pom.latestFinal.kieserverSnapDistZip}[Distribution ZIP]
+
+  |*kie tomcat integration*
+  |#{site.pom.latestFinal.tomcatIntergrationSnap}[Tomcat integration JAR]
+
+  |*org.drools.updatesite*
+  |#{site.pom.latestFinal.updatesiteSnapZip}[updatesite ZIP]
+
+  |===


### PR DESCRIPTION
@etirelli 
please look at the recent status of https://downloads.jboss.org/drools/release/snapshot/master/index.html. This page is not nice and not adapted to the look and feel of the web page.
This was the reason a new page was introduced.
Please look at the wording. Maybe you prefer to use other explaining words.
If you're OK with this please merge this PR - then it will be automatically published.
![SelectedNightlySnapshots](https://user-images.githubusercontent.com/3669059/62940690-66fbb880-bdd4-11e9-8938-74f7c76b7d83.png)
