### PR TITLE
removed link that points to URL not existing anymore

### DIFF
--- a/code/sourceCode.adoc
+++ b/code/sourceCode.adoc
@@ -38,12 +38,3 @@ It's easy to keep an eye on the source code changes on the project:
 * Anonymous: http://anonsvn.jboss.org/repos/labs/labs/jbossrules/trunk/[http://anonsvn.jboss.org/repos/labs/labs/jbossrules/trunk/]
 * Committer: https://svn.jboss.org/repos/labs/labs/jbossrules/trunk/[https://svn.jboss.org/repos/labs/labs/jbossrules/trunk/]
 
-== Continuous integration
-:awestruct-layout: normalBase
-:showtitle:
-
-We use Jenkins for continuous integration.
-
-*Show http://ci.drools.org/[the Jenkins jobs].* These are mirrors of a Red Hat internal Jenkins jobs.
-
-Keep the builds green!


### PR DESCRIPTION
link removed that call an not any more existing URL: http://ci.drools.org/
Jenkins is behind the VPN - so not accessible publicly. This link was removed since broken links are bad for Google ranking.