### PR TITLE
Update links to Docker registery

### DIFF
--- a/download/download.adoc
+++ b/download/download.adoc
@@ -96,10 +96,10 @@
 === http://www.docker.com/[Docker] images
 
 * You can find the Docker images and how to use them for last final version  at
-** https://registry.hub.docker.com/u/jboss/business-central-workbench/[Business Central Workbench]
-** https://registry.hub.docker.com/u/jboss/business-central-workbench-showcase/[Business Central Workbench Showcase]
-** https://registry.hub.docker.com/u/jboss/kie-server/[KIE Execution Server]
-** https://registry.hub.docker.com/u/jboss/kie-server-showcase/[KIE Execution Server Showcase]
+** https://registry.hub.docker.com/r/jboss/business-central-workbench/[Business Central Workbench]
+** https://registry.hub.docker.com/r/jboss/business-central-workbench-showcase/[Business Central Workbench Showcase]
+** https://registry.hub.docker.com/r/jboss/kie-server/[KIE Execution Server]
+** https://registry.hub.docker.com/r/jboss/kie-server-showcase/[KIE Execution Server Showcase]
 
 For more info about the Drools Docker images see this http://blog.athico.com/2015/06/drools-jbpm-get-dockerized.html[blog post].
 

--- a/index.html.haml
+++ b/index.html.haml
@@ -111,13 +111,13 @@ layout: base
       %span Try our Docker images and run Drools in just seconds
       %ul
         %li
-          %a(href="http://registry.hub.docker.com/u/jboss/business-central-workbench/")Business Central Workbench
+          %a(href="http://registry.hub.docker.com/r/jboss/business-central-workbench/")Business Central Workbench
         %li
-          %a(href="http://registry.hub.docker.com/u/jboss/business-central-workbench-showcase/")Business Central Workbench Showcase
+          %a(href="http://registry.hub.docker.com/r/jboss/business-central-workbench-showcase/")Business Central Workbench Showcase
         %li
-          %a(href="http://registry.hub.docker.com/u/jboss/kie-server/")KIE Execution Server
+          %a(href="http://registry.hub.docker.com/r/jboss/kie-server/")KIE Execution Server
         %li
-          %a(href="http://registry.hub.docker.com/u/jboss/kie-server-showcase/")KIE Execution Server Showcase
+          %a(href="http://registry.hub.docker.com/r/jboss/kie-server-showcase/")KIE Execution Server Showcase
       .small
         More info at 
         %a(href="http://blog.athico.com/2015/06/drools-jbpm-get-dockerized.html")this post

--- a/index.html.haml
+++ b/index.html.haml
@@ -111,13 +111,13 @@ layout: base
       %span Try our Docker images and run Drools in just seconds
       %ul
         %li
-          %a(href="http://registry.hub.docker.com/r/jboss/business-central-workbench/")Business Central Workbench
+          %a(href="https://registry.hub.docker.com/r/jboss/business-central-workbench/")Business Central Workbench
         %li
-          %a(href="http://registry.hub.docker.com/r/jboss/business-central-workbench-showcase/")Business Central Workbench Showcase
+          %a(href="https://registry.hub.docker.com/r/jboss/business-central-workbench-showcase/")Business Central Workbench Showcase
         %li
-          %a(href="http://registry.hub.docker.com/r/jboss/kie-server/")KIE Execution Server
+          %a(href="https://registry.hub.docker.com/r/jboss/kie-server/")KIE Execution Server
         %li
-          %a(href="http://registry.hub.docker.com/r/jboss/kie-server-showcase/")KIE Execution Server Showcase
+          %a(href="https://registry.hub.docker.com/r/jboss/kie-server-showcase/")KIE Execution Server Showcase
       .small
         More info at 
         %a(href="http://blog.athico.com/2015/06/drools-jbpm-get-dockerized.html")this post


### PR DESCRIPTION
The current URLs take a user to a blank page. Updated the URLs to point to the overview page for the docker image.