### PR TITLE
upgraded to 7.43.1.Final

### DIFF
--- a/_config/pom.yml
+++ b/_config/pom.yml
@@ -16,27 +16,27 @@ kieExecutionServerDescription: Standalone execution server that can be used to r
 kieWarsDescription: WAR files for all supported containers
 
 latestFinal:
-    version: 7.43.0.Final
-    releaseDate: 2020-09-09
+    version: 7.43.1.Final
+    releaseDate: 2020-09-14
 
-    droolsZip: https://download.jboss.org/drools/release/7.43.0.Final/drools-distribution-7.43.0.Final.zip
+    droolsZip: https://download.jboss.org/drools/release/7.43.1.Final/drools-distribution-7.43.1.Final.zip
 
-    droolsjbpmIntegrationZip: https://download.jboss.org/drools/release/7.43.0.Final/droolsjbpm-integration-distribution-7.43.0.Final.zip
+    droolsjbpmIntegrationZip: https://download.jboss.org/drools/release/7.43.1.Final/droolsjbpm-integration-distribution-7.43.1.Final.zip
 
-    businessCentralEAP7WAR: https://download.jboss.org/drools/release/7.43.0.Final/business-central-7.43.0.Final-eap7.war
-    businessCentralWildFlyWAR: https://download.jboss.org/drools/release/7.43.0.Final/business-central-7.43.0.Final-wildfly19.war
+    businessCentralEAP7WAR: https://download.jboss.org/drools/release/7.43.1.Final/business-central-7.43.1.Final-eap7.war
+    businessCentralWildFlyWAR: https://download.jboss.org/drools/release/7.43.1.Final/business-central-7.43.1.Final-wildfly19.war
 
-    droolsjbpmToolsZip: https://download.jboss.org/drools/release/7.43.0.Final/droolsjbpm-tools-distribution-7.43.0.Final.zip
+    droolsjbpmToolsZip: https://download.jboss.org/drools/release/7.43.1.Final/droolsjbpm-tools-distribution-7.43.1.Final.zip
 
-    documentationHtmlSingle: https://docs.jboss.org/drools/release/7.43.0.Final/drools-docs/html_single/index.html
+    documentationHtmlSingle: https://docs.jboss.org/drools/release/7.43.1.Final/drools-docs/html_single/index.html
 
-    KIE_API_documentationJavadoc: https://docs.jboss.org/drools/release/7.43.0.Final/kie-api-javadoc/index.html
+    KIE_API_documentationJavadoc: https://docs.jboss.org/drools/release/7.43.1.Final/kie-api-javadoc/index.html
 
-    droolsWhatsNew: https://docs.jboss.org/drools/release/7.43.0.Final/drools-docs/html_single/#_droolsreleasenoteschapter
-    droolsReleaseNotes: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=12313021&version=12347004
+    droolsWhatsNew: https://docs.jboss.org/drools/release/7.43.1.Final/drools-docs/html_single/#_droolsreleasenoteschapter
+    droolsReleaseNotes: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=12313021&version=12350276
 
-    kieExecutionServerZip: https://download.jboss.org/drools/release/7.43.0.Final/kie-server-distribution-7.43.0.Final.zip
-    kieWARS: https://repo1.maven.org/maven2/org/kie/server/kie-server/7.43.0.Final/
+    kieExecutionServerZip: https://download.jboss.org/drools/release/7.43.1.Final/kie-server-distribution-7.43.1.Final.zip
+    kieWARS: https://repo1.maven.org/maven2/org/kie/server/kie-server/7.43.1.Final/
 
     userGuideBook: https://www.gitbook.com/@nheron
     userGuidePDF: https://nicolas-heron.gitbook.io/droolsonboarding/
@@ -53,28 +53,28 @@ latestFinal:
 
 # latest.version can be equal to latestFinal.version
 latest:
-    version: 7.43.0.Final
-    releaseDate: 2020-09-09
-    droolsZip: https://download.jboss.org/drools/release/7.43.0.Final/drools-distribution-7.43.0.Final.zip
+    version: 7.43.1.Final
+    releaseDate: 2020-09-14
+    droolsZip: https://download.jboss.org/drools/release/7.43.1.Final/drools-distribution-7.43.1.Final.zip
 
-    droolsjbpmIntegrationZip: https://download.jboss.org/drools/release/7.43.0.Final/droolsjbpm-integration-distribution-7.43.0.Final.zip
+    droolsjbpmIntegrationZip: https://download.jboss.org/drools/release/7.43.1.Final/droolsjbpm-integration-distribution-7.43.1.Final.zip
 
-    droolsWorkbenchEAP7WAR: https://download.jboss.org/drools/release/7.43.0.Final/business-central-7.43.0.Final-eap7.war
-    droolsWorkbenchWildFlyWAR: https://download.jboss.org/drools/release/7.43.0.Final/business-central-7.43.0.Final-wildfly19.war
-    droolsWorkbenchJcr2vfsZip: https://download.jboss.org/drools/release/7.43.0.Final/drools-wb-jcr2vfs-distribution-7.43.0.Final.zip
-    droolsWorkbenchExampleGitReposZip: https://download.jboss.org/drools/release/7.43.0.Final/kie-wb-example-repositories-7.43.0.Final.zip
+    droolsWorkbenchEAP7WAR: https://download.jboss.org/drools/release/7.43.1.Final/business-central-7.43.1.Final-eap7.war
+    droolsWorkbenchWildFlyWAR: https://download.jboss.org/drools/release/7.43.1.Final/business-central-7.43.1.Final-wildfly19.war
+    droolsWorkbenchJcr2vfsZip: https://download.jboss.org/drools/release/7.43.1.Final/drools-wb-jcr2vfs-distribution-7.43.1.Final.zip
+    droolsWorkbenchExampleGitReposZip: https://download.jboss.org/drools/release/7.43.1.Final/kie-wb-example-repositories-7.43.1.Final.zip
 
-    droolsjbpmToolsZip: https://download.jboss.org/drools/release/7.43.0.Final/droolsjbpm-tools-distribution-7.43.0.Final.zip
+    droolsjbpmToolsZip: https://download.jboss.org/drools/release/7.43.1.Final/droolsjbpm-tools-distribution-7.43.1.Final.zip
 
-    documentationHtmlSingle: https://docs.jboss.org/drools/release/7.43.0.Final/drools-docs/html_single/index.html
+    documentationHtmlSingle: https://docs.jboss.org/drools/release/7.43.1.Final/drools-docs/html_single/index.html
 
-    KIE_API_documentationJavadoc: https://docs.jboss.org/drools/release/7.43.0.Final/kie-api-javadoc/index.html
+    KIE_API_documentationJavadoc: https://docs.jboss.org/drools/release/7.43.1.Final/kie-api-javadoc/index.html
 
-    droolsWhatsNew: https://docs.jboss.org/drools/release/7.43.0.Final/drools-docs/html_single/#_droolsreleasenoteschapter
-    droolsReleaseNotes: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=12313021&version=12347004
+    droolsWhatsNew: https://docs.jboss.org/drools/release/7.43.1.Final/drools-docs/html_single/#_droolsreleasenoteschapter
+    droolsReleaseNotes: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=12313021&version=12350276
 
-    kieExecutionServerZip: https://download.jboss.org/drools/release/7.43.0.Final/kie-server-distribution-7.43.0.Final.zip
-    kieWARS: https://repo1.maven.org/maven2/org/kie/server/kie-server/7.43.0.Final/
+    kieExecutionServerZip: https://download.jboss.org/drools/release/7.43.1.Final/kie-server-distribution-7.43.1.Final.zip
+    kieWARS: https://repo1.maven.org/maven2/org/kie/server/kie-server/7.43.1.Final/
 
 # since there are two branches 7.0.x and 6.5.x and there are releases for both, they have to be shown
 


### PR DESCRIPTION
@mariofusco  since this was an intermittent release the link:
drools: https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12313021&version=12350276
On the drools-web shows an empty text box. There haven't been no JIRAS assigned to this release.

Please merge when you're OK with this.