### PR TITLE
restructure of Dockerfile

### DIFF
--- a/_dockerPublisher/Dockerfile
+++ b/_dockerPublisher/Dockerfile
@@ -11,35 +11,26 @@ MAINTAINER "Michael Biarnes Kiefer <mbiarnes@redhat.com>"
 ### swith to root user ###
 USER root
 
-### install ruby and rake ###
-RUN dnf install -y ruby
-RUN dnf install -y rubygems
-RUN dnf install -y rubygem-rake
-RUN dnf install -y rubygem-bundler
-RUN dnf install -y ruby-devel
-RUN dnf install -y rpm-build
-RUN dnf install -y gcc-c++
-RUN dnf install -y make
-RUN dnf install -y rsync
-RUN dnf install -y openssh-clients
-RUN dnf install -y net-tools
-RUN dnf install -y iputils
-RUN dnf install -y wget
+### Install ruby dependencies
+RUN dnf install -y ruby rubygems rubygem-rake rubygem-bundler ruby-devel \
+## Install tools \
+    rpm-build gcc-c++ make rsync openssh-clients net-tools iputils wget
+
 RUN dnf clean all
 
 RUN bash -l -c "gem install bundler awestruct"
 
-RUN useradd -m jenkins -u 1001 --shell /bin/bash
+RUN useradd -m jenkins -u 1000 --shell /bin/bash
 RUN usermod -a -G wheel jenkins
 
 #change permissions in sudoers
 RUN sed -i 's/# %wheel	ALL=(ALL)	NOPASSWD: ALL/%wheel	ALL=(ALL)	NOPASSWD: ALL/g' /etc/sudoers
 
-
 USER jenkins
 
 WORKDIR /home/jenkins
 
+RUN mkdir /home/jenkins/.ssh
 RUN wget https://github.com/kiegroup/drools-website/archive/master.zip
 RUN unzip master.zip
 


### PR DESCRIPTION
- Dockerfile doesn't create any more so many layers
- the users UID (jenkins) was changed to 1000 to match the uid inside the docker container
- the directory /home/jenkins/.ssh (where all keys are stored) will be created already when building the image
 (this is needed for future Jenkins jobs)