### PR TITLE
upgraded to 7.49.0.Final

### DIFF
--- a/_config/pom.yml
+++ b/_config/pom.yml
@@ -16,65 +16,67 @@ kieExecutionServerDescription: Standalone execution server that can be used to r
 kieWarsDescription: WAR files for all supported containers
 
 latestFinal:
-    version: 7.48.0.Final
-    releaseDate: 2021-01-13
+    version: 7.49.0.Final
+    releaseDate: 2021-02-03
 
-    droolsZip: https://download.jboss.org/drools/release/7.48.0.Final/drools-distribution-7.48.0.Final.zip
+    droolsZip: https://download.jboss.org/drools/release/7.49.0.Final/drools-distribution-7.49.0.Final.zip
 
-    droolsjbpmIntegrationZip: https://download.jboss.org/drools/release/7.48.0.Final/droolsjbpm-integration-distribution-7.48.0.Final.zip
+    droolsjbpmIntegrationZip: https://download.jboss.org/drools/release/7.49.0.Final/droolsjbpm-integration-distribution-7.49.0.Final.zip
 
-    businessCentralEAP7WAR: https://download.jboss.org/drools/release/7.48.0.Final/business-central-7.48.0.Final-eap7.war
-    businessCentralWildFlyWAR: https://download.jboss.org/drools/release/7.48.0.Final/business-central-7.48.0.Final-wildfly19.war
+    businessCentralEAP7WAR: https://download.jboss.org/drools/release/7.49.0.Final/business-central-7.49.0.Final-eap7.war
+    businessCentralWildFlyWAR: https://download.jboss.org/drools/release/7.49.0.Final/business-central-7.49.0.Final-wildfly19.war
 
-    droolsjbpmToolsZip: https://download.jboss.org/drools/release/7.48.0.Final/droolsjbpm-tools-distribution-7.48.0.Final.zip
 
-    documentationHtmlSingle: https://docs.jboss.org/drools/release/7.48.0.Final/drools-docs/html_single/index.html
+    latestDroolsJbpmToolsZip: https://download.jboss.org/drools/release/7.48.0.Final/droolsjbpm-tools-distribution-7.48.0.Final.zip
+    # droolsjbpmToolsZip: https://download.jboss.org/drools/release/7.49.0.Final/droolsjbpm-tools-distribution-7.49.0.Final.zip
 
-    KIE_API_documentationJavadoc: https://docs.jboss.org/drools/release/7.48.0.Final/kie-api-javadoc/index.html
+    documentationHtmlSingle: https://docs.jboss.org/drools/release/7.49.0.Final/drools-docs/html_single/index.html
 
-    droolsWhatsNew: https://docs.jboss.org/drools/release/7.48.0.Final/drools-docs/html_single/#_droolsreleasenoteschapter
-    droolsReleaseNotes: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=12313021&version=12352663
+    KIE_API_documentationJavadoc: https://docs.jboss.org/drools/release/7.49.0.Final/kie-api-javadoc/index.html
 
-    kieExecutionServerZip: https://download.jboss.org/drools/release/7.48.0.Final/kie-server-distribution-7.48.0.Final.zip
-    kieWARS: https://repo1.maven.org/maven2/org/kie/server/kie-server/7.48.0.Final/
+    droolsWhatsNew: https://docs.jboss.org/drools/release/7.49.0.Final/drools-docs/html_single/#_droolsreleasenoteschapter
+    droolsReleaseNotes: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=12313021&version=12352975
+
+    kieExecutionServerZip: https://download.jboss.org/drools/release/7.49.0.Final/kie-server-distribution-7.49.0.Final.zip
+    kieWARS: https://repo1.maven.org/maven2/org/kie/server/kie-server/7.49.0.Final/
 
     userGuideBook: https://www.gitbook.com/@nheron
     userGuidePDF: https://nicolas-heron.gitbook.io/droolsonboarding/
 
-    droolsSnapZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.drools&a=drools-distribution&v=7.49.0-SNAPSHOT&e=zip
-    jbpmSnapZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.jbpm&a=jbpm-distribution&v=7.49.0-SNAPSHOT&e=zip&c=bin
-    businessCentralSnapWF: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie&a=business-central&v=7.49.0-SNAPSHOT&e=war&c=wildfly19
-    kieserverSnapEe7: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=7.49.0-SNAPSHOT&e=war&c=ee7
-    kieserverSnapEe8: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=7.49.0-SNAPSHOT&e=war&c=ee8
-    kieserverSnapWebc: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=7.49.0-SNAPSHOT&e=war&c=webc
-    kieserverSnapDistZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server-distribution&v=7.49.0-SNAPSHOT&e=zip
-    tomcatIntergrationSnap: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie&a=kie-tomcat-integration&v=7.49.0-SNAPSHOT&e=jar
-    updatesiteSnapZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.drools&a=org.drools.updatesite&v=7.49.0-SNAPSHOT&e=zip
+    droolsSnapZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.drools&a=drools-distribution&v=7.50.0-SNAPSHOT&e=zip
+    jbpmSnapZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.jbpm&a=jbpm-distribution&v=7.50.0-SNAPSHOT&e=zip&c=bin
+    businessCentralSnapWF: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie&a=business-central&v=7.50.0-SNAPSHOT&e=war&c=wildfly19
+    kieserverSnapEe7: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=7.50.0-SNAPSHOT&e=war&c=ee7
+    kieserverSnapEe8: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=7.50.0-SNAPSHOT&e=war&c=ee8
+    kieserverSnapWebc: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=7.50.0-SNAPSHOT&e=war&c=webc
+    kieserverSnapDistZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server-distribution&v=7.50.0-SNAPSHOT&e=zip
+    tomcatIntergrationSnap: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie&a=kie-tomcat-integration&v=7.50.0-SNAPSHOT&e=jar
+    # updatesiteSnapZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.drools&a=org.drools.updatesite&v=7.50.0-SNAPSHOT&e=zip
 
 # latest.version can be equal to latestFinal.version
 latest:
-    version: 7.48.0.Final
-    releaseDate: 2021-01-13
-    droolsZip: https://download.jboss.org/drools/release/7.48.0.Final/drools-distribution-7.48.0.Final.zip
+    version: 7.49.0.Final
+    releaseDate: 2021-02-03
+    droolsZip: https://download.jboss.org/drools/release/7.49.0.Final/drools-distribution-7.49.0.Final.zip
 
-    droolsjbpmIntegrationZip: https://download.jboss.org/drools/release/7.48.0.Final/droolsjbpm-integration-distribution-7.48.0.Final.zip
+    droolsjbpmIntegrationZip: https://download.jboss.org/drools/release/7.49.0.Final/droolsjbpm-integration-distribution-7.49.0.Final.zip
 
-    droolsWorkbenchEAP7WAR: https://download.jboss.org/drools/release/7.48.0.Final/business-central-7.48.0.Final-eap7.war
-    droolsWorkbenchWildFlyWAR: https://download.jboss.org/drools/release/7.48.0.Final/business-central-7.48.0.Final-wildfly19.war
-    droolsWorkbenchJcr2vfsZip: https://download.jboss.org/drools/release/7.48.0.Final/drools-wb-jcr2vfs-distribution-7.48.0.Final.zip
-    droolsWorkbenchExampleGitReposZip: https://download.jboss.org/drools/release/7.48.0.Final/kie-wb-example-repositories-7.48.0.Final.zip
+    droolsWorkbenchEAP7WAR: https://download.jboss.org/drools/release/7.49.0.Final/business-central-7.49.0.Final-eap7.war
+    droolsWorkbenchWildFlyWAR: https://download.jboss.org/drools/release/7.49.0.Final/business-central-7.49.0.Final-wildfly19.war
+    droolsWorkbenchJcr2vfsZip: https://download.jboss.org/drools/release/7.49.0.Final/drools-wb-jcr2vfs-distribution-7.49.0.Final.zip
+    droolsWorkbenchExampleGitReposZip: https://download.jboss.org/drools/release/7.49.0.Final/kie-wb-example-repositories-7.49.0.Final.zip
 
-    droolsjbpmToolsZip: https://download.jboss.org/drools/release/7.48.0.Final/droolsjbpm-tools-distribution-7.48.0.Final.zip
+    # droolsjbpmToolsZip: https://download.jboss.org/drools/release/7.49.0.Final/droolsjbpm-tools-distribution-7.49.0.Final.zip
 
-    documentationHtmlSingle: https://docs.jboss.org/drools/release/7.48.0.Final/drools-docs/html_single/index.html
+    documentationHtmlSingle: https://docs.jboss.org/drools/release/7.49.0.Final/drools-docs/html_single/index.html
 
-    KIE_API_documentationJavadoc: https://docs.jboss.org/drools/release/7.48.0.Final/kie-api-javadoc/index.html
+    KIE_API_documentationJavadoc: https://docs.jboss.org/drools/release/7.49.0.Final/kie-api-javadoc/index.html
 
-    droolsWhatsNew: https://docs.jboss.org/drools/release/7.48.0.Final/drools-docs/html_single/#_droolsreleasenoteschapter
-    droolsReleaseNotes: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=12313021&version=12352663
+    droolsWhatsNew: https://docs.jboss.org/drools/release/7.49.0.Final/drools-docs/html_single/#_droolsreleasenoteschapter
+    droolsReleaseNotes: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=12313021&version=12352975
 
-    kieExecutionServerZip: https://download.jboss.org/drools/release/7.48.0.Final/kie-server-distribution-7.48.0.Final.zip
-    kieWARS: https://repo1.maven.org/maven2/org/kie/server/kie-server/7.48.0.Final/
+    kieExecutionServerZip: https://download.jboss.org/drools/release/7.49.0.Final/kie-server-distribution-7.49.0.Final.zip
+    kieWARS: https://repo1.maven.org/maven2/org/kie/server/kie-server/7.49.0.Final/
 
 # since there are two branches 7.0.x and 6.5.x and there are releases for both, they have to be shown
 

--- a/download/download.adoc
+++ b/download/download.adoc
@@ -26,10 +26,6 @@
 |#{site.pom.businessCentralDescription}
 |#{site.pom.latestFinal.businessCentralWildFlyWAR}[WildFly 19 WAR]
 
-|*Drools and jBPM tools*
-|#{site.pom.droolsjbpmToolsDescription}
-|#{site.pom.latestFinal.droolsjbpmToolsZip}[Distribution ZIP]
-
 |*KIE Execution Server*
 |#{site.pom.kieExecutionServerDescription}
 |#{site.pom.latestFinal.kieExecutionServerZip}[Distribution ZIP]
@@ -115,6 +111,8 @@ For more info about the Drools Docker images see this http://blog.athico.com/201
 
 === Eclipse update site
 
-* https://download.jboss.org/drools/release/#{site.pom.latestFinal.version}/org.drools.updatesite/[Click here] to go to the Drools and jBPM update site #{site.pom.latestFinal.version}.
+We stopped to release Eclipse tools synchronously with Drools, thus the recent version of Drools and of latest released Eclipse tools (updatesite) may differ.
+
+* https://download.jboss.org/drools/release/7.48.0.Final/org.drools.updatesite/[Click here] to go to the Drools and jBPM update site (latest released version *7.48.0.Final*).
 * The Drools and jBPM plugin for Eclipse can also be discovered from https://www.jboss.org/tools[JBoss Tools].
-* Alternatively, you can download the "Drools and jBPM tools" zip (from the table above), unzip it and configure the directory "binaries/org.drools.updatesite" as a local updatesite.
+* Alternatively, you can download the latest released version of #{site.pom.latestFinal.latestDroolsJbpmToolsZip}[Drools and jBPM tools zip] (*7.48.0.Final*), unzip it and configure the directory "binaries/org.drools.updatesite" as a local updatesite.


### PR DESCRIPTION
changes:
![image](https://user-images.githubusercontent.com/3669059/106883440-4322e580-66e0-11eb-9b6a-c91de2f72aff.png)

The links always link to the latest stable and released version **7.48.0.Final** of updatesite