### PR TITLE
Adding a link to the blog

### DIFF
--- a/_layouts/base.html.haml
+++ b/_layouts/base.html.haml
@@ -62,7 +62,7 @@
         .collapse.navbar-collapse#baseNavigation
           %ul.nav.navbar-nav
             %li<
-              %a{:href => relative("/")} Home
+              %a{:href => "https://blog.kie.org"} Blog
             %li<
               %a{:href => relative("/download/download.html")} Download
             %li.dropdown


### PR DESCRIPTION
Swapping out "Home" for "Blog" the logo already links back to home, so no point in having two of them.