### PR TITLE
fix release date from pom.yml in alert

### DIFF
--- a/templates/index.ftl
+++ b/templates/index.ftl
@@ -14,7 +14,7 @@
             <i class="fas fa-info-circle"></i>
             <!-- 2021-08-05: -->
             <!-- %a.alert-link(href="https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=12313021&version=12359307")Drools 7.58.0.Final has been released. -->
-            2021-08-05:
+            ${pom.latest.releaseDate?string("yyyy-MM-dd")}:
             <a class="alert-link"
             href="${pom.latest.droolsReleaseNotes}">Drools ${pom.latestFinal.version} has been released.</a>
             <button class="btn-close" data-bs-dismiss="alert" type="button" aria-label="Close"></button>


### PR DESCRIPTION
Before Vs After

![Screenshot 2021-11-02 at 15 33 53](https://user-images.githubusercontent.com/1699252/139867975-9789a45f-b390-4638-a21a-afdcbd7d486f.png)


