### PR TITLE
upgraded to 7.61.0.Final version

### DIFF
--- a/data/pom.yml
+++ b/data/pom.yml
@@ -11,32 +11,32 @@ kieExecutionServerDescription: Standalone execution server that can be used to r
 kieWarsDescription: WAR files for all supported containers
 
 latestFinal:
-    version: 7.60.0.Final
-    releaseDate: 2021-09-18
+    version: 7.61.0.Final
+    releaseDate: 2021-11-04
 
-    droolsZip: https://download.jboss.org/drools/release/7.60.0.Final/drools-distribution-7.60.0.Final.zip
+    droolsZip: https://download.jboss.org/drools/release/7.61.0.Final/drools-distribution-7.61.0.Final.zip
 
-    droolsjbpmIntegrationZip: https://download.jboss.org/drools/release/7.60.0.Final/droolsjbpm-integration-distribution-7.60.0.Final.zip
+    droolsjbpmIntegrationZip: https://download.jboss.org/drools/release/7.61.0.Final/droolsjbpm-integration-distribution-7.61.0.Final.zip
 
-    businessCentralEAP7WAR: https://download.jboss.org/drools/release/7.60.0.Final/business-central-7.60.0.Final-eap7.war
-    businessCentralWildFlyWAR: https://download.jboss.org/drools/release/7.60.0.Final/business-central-7.60.0.Final-wildfly19.war
+    businessCentralEAP7WAR: https://download.jboss.org/drools/release/7.61.0.Final/business-central-7.61.0.Final-eap7.war
+    businessCentralWildFlyWAR: https://download.jboss.org/drools/release/7.61.0.Final/business-central-7.61.0.Final-wildfly23.war
 
     # as part of the migration to JBAke we have a regex based script to update the version
     # as the below is hardcoded to a fixed version, we just inline the value in the content pages for now, so the regex based script won't change them
     # droolsjbpm-tools iss not released any more, last stable version is 7. 46.0.Final
     # latestDroolsJbpmToolsZip: https://download.jboss.org/drools/release/7. 46.0.Final/droolsjbpm-tools-distribution-7. 46.0.Final.zip
 
-    # droolsjbpmToolsZip: https://download.jboss.org/drools/release/7.60.0.Final/droolsjbpm-tools-distribution-7.60.0.Final.zip
+    # droolsjbpmToolsZip: https://download.jboss.org/drools/release/7.61.0.Final/droolsjbpm-tools-distribution-7.61.0.Final.zip
 
-    documentationHtmlSingle: https://docs.jboss.org/drools/release/7.60.0.Final/drools-docs/html_single/index.html
+    documentationHtmlSingle: https://docs.jboss.org/drools/release/7.61.0.Final/drools-docs/html_single/index.html
 
-    KIE_API_documentationJavadoc: https://docs.jboss.org/drools/release/7.60.0.Final/kie-api-javadoc/index.html
+    KIE_API_documentationJavadoc: https://docs.jboss.org/drools/release/7.61.0.Final/kie-api-javadoc/index.html
 
-    droolsWhatsNew: https://docs.jboss.org/drools/release/7.60.0.Final/drools-docs/html_single/#_droolsreleasenoteschapter
-    droolsReleaseNotes: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=12313021&version=12373519
+    droolsWhatsNew: https://docs.jboss.org/drools/release/7.61.0.Final/drools-docs/html_single/#_droolsreleasenoteschapter
+    droolsReleaseNotes: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=12313021&version=12375651
 
-    kieExecutionServerZip: https://download.jboss.org/drools/release/7.60.0.Final/kie-server-distribution-7.60.0.Final.zip
-    kieWARS: https://repo1.maven.org/maven2/org/kie/server/kie-server/7.60.0.Final/
+    kieExecutionServerZip: https://download.jboss.org/drools/release/7.61.0.Final/kie-server-distribution-7.61.0.Final.zip
+    kieWARS: https://repo1.maven.org/maven2/org/kie/server/kie-server/7.61.0.Final/
 
     userGuideBook: https://www.gitbook.com/@nheron
     userGuidePDF: https://nicolas-heron.gitbook.io/droolsonboarding/
@@ -53,28 +53,28 @@ latestFinal:
 
 # latest.version can be equal to latestFinal.version
 latest:
-    version: 7.60.0.Final
-    releaseDate: 2021-09-18
-    droolsZip: https://download.jboss.org/drools/release/7.60.0.Final/drools-distribution-7.60.0.Final.zip
+    version: 7.61.0.Final
+    releaseDate: 2021-11-04
+    droolsZip: https://download.jboss.org/drools/release/7.61.0.Final/drools-distribution-7.61.0.Final.zip
 
-    droolsjbpmIntegrationZip: https://download.jboss.org/drools/release/7.60.0.Final/droolsjbpm-integration-distribution-7.60.0.Final.zip
+    droolsjbpmIntegrationZip: https://download.jboss.org/drools/release/7.61.0.Final/droolsjbpm-integration-distribution-7.61.0.Final.zip
 
-    droolsWorkbenchEAP7WAR: https://download.jboss.org/drools/release/7.60.0.Final/business-central-7.60.0.Final-eap7.war
-    droolsWorkbenchWildFlyWAR: https://download.jboss.org/drools/release/7.60.0.Final/business-central-7.60.0.Final-wildfly19.war
-    droolsWorkbenchJcr2vfsZip: https://download.jboss.org/drools/release/7.60.0.Final/drools-wb-jcr2vfs-distribution-7.60.0.Final.zip
-    droolsWorkbenchExampleGitReposZip: https://download.jboss.org/drools/release/7.60.0.Final/kie-wb-example-repositories-7.60.0.Final.zip
+    droolsWorkbenchEAP7WAR: https://download.jboss.org/drools/release/7.61.0.Final/business-central-7.61.0.Final-eap7.war
+    droolsWorkbenchWildFlyWAR: https://download.jboss.org/drools/release/7.61.0.Final/business-central-7.61.0.Final-wildfly23.war
+    droolsWorkbenchJcr2vfsZip: https://download.jboss.org/drools/release/7.61.0.Final/drools-wb-jcr2vfs-distribution-7.61.0.Final.zip
+    droolsWorkbenchExampleGitReposZip: https://download.jboss.org/drools/release/7.61.0.Final/kie-wb-example-repositories-7.61.0.Final.zip
 
-    # droolsjbpmToolsZip: https://download.jboss.org/drools/release/7.60.0.Final/droolsjbpm-tools-distribution-7.60.0.Final.zip
+    # droolsjbpmToolsZip: https://download.jboss.org/drools/release/7.61.0.Final/droolsjbpm-tools-distribution-7.61.0.Final.zip
 
-    documentationHtmlSingle: https://docs.jboss.org/drools/release/7.60.0.Final/drools-docs/html_single/index.html
+    documentationHtmlSingle: https://docs.jboss.org/drools/release/7.61.0.Final/drools-docs/html_single/index.html
 
-    KIE_API_documentationJavadoc: https://docs.jboss.org/drools/release/7.60.0.Final/kie-api-javadoc/index.html
+    KIE_API_documentationJavadoc: https://docs.jboss.org/drools/release/7.61.0.Final/kie-api-javadoc/index.html
 
-    droolsWhatsNew: https://docs.jboss.org/drools/release/7.60.0.Final/drools-docs/html_single/#_droolsreleasenoteschapter
-    droolsReleaseNotes: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=12313021&version=12373519
+    droolsWhatsNew: https://docs.jboss.org/drools/release/7.61.0.Final/drools-docs/html_single/#_droolsreleasenoteschapter
+    droolsReleaseNotes: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=12313021&version=12375651
 
-    kieExecutionServerZip: https://download.jboss.org/drools/release/7.60.0.Final/kie-server-distribution-7.60.0.Final.zip
-    kieWARS: https://repo1.maven.org/maven2/org/kie/server/kie-server/7.60.0.Final/
+    kieExecutionServerZip: https://download.jboss.org/drools/release/7.61.0.Final/kie-server-distribution-7.61.0.Final.zip
+    kieWARS: https://repo1.maven.org/maven2/org/kie/server/kie-server/7.61.0.Final/
 
 # since there are two branches 7.0.x and 6.5.x and there are releases for both, they have to be shown
 

--- a/templates/_content_download_download.ftl
+++ b/templates/_content_download_download.ftl
@@ -64,7 +64,7 @@
                         <td class="tableblock halign-left valign-top"><p
                                     class="tableblock">${pom.businessCentralDescription}</p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock"><a
-                                href="${pom.latestFinal.businessCentralWildFlyWAR}">WildFly 19 WAR</a></p></td>
+                                href="${pom.latestFinal.businessCentralWildFlyWAR}">WildFly 23 WAR</a></p></td>
                     </tr>
                     <tr>
                         <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>KIE Execution


### PR DESCRIPTION
@tarilabs artifacts should be on filemgmt.jbos.org. 
Due to this [outage](https://one.redhat.com/legacy/outages/list/details/61835335b8cd3b0e2d1900d3) Jenkins takes long,long time to run a job. Look at the Jenkins queue.
I mean when you merge this it could take its time to start.