### PR TITLE
fix rendering server side date UTC

### DIFF
--- a/templates/base.ftl
+++ b/templates/base.ftl
@@ -6,6 +6,8 @@
     ((content.type == "post")?then(content.body?replace("<[\\w/][^>]*>", "", "r")?replace("\\s+", " ", "r")?truncate(200, "...")?trim,
     ((description == "")?then(config.errorDescriptionIsMandatory, description))))/>
 <#assign _uri = content.uri!uri/>
+<#setting time_zone="UTC">
+<#setting sql_date_and_time_time_zone="JVM default"><#-- as indicated by FreeMarker doc after setting time_zone=UTC manually -->
 <!DOCTYPE html>
 <html lang="${(content.lang)!"en"}">
 <head>

--- a/templates/index.ftl
+++ b/templates/index.ftl
@@ -14,7 +14,7 @@
             <i class="fas fa-info-circle"></i>
             <!-- 2021-08-05: -->
             <!-- %a.alert-link(href="https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=12313021&version=12359307")Drools 7.58.0.Final has been released. -->
-            ${pom.latest.releaseDate?string("yyyy-MM-dd")}:
+            ${pom.latest.releaseDate?date?string.iso}:
             <a class="alert-link"
             href="${pom.latest.droolsReleaseNotes}">Drools ${pom.latestFinal.version} has been released.</a>
             <button class="btn-close" data-bs-dismiss="alert" type="button" aria-label="Close"></button>


### PR DESCRIPTION
As the server TZ always likely differ from each developer TZ settings, the only reasonable FreeMarker setting is UTC. This way the formatter will assume the date we write in the configuration, yamls, etc, will be referring to UTC.

This approach could also solve analogous problem also for Optaplanner-website, example:
![Screenshot 2021-11-04 at 15 36 03](https://user-images.githubusercontent.com/1699252/140341111-e62a0afa-f71c-4c62-aed7-be78c5bb4d29.png)

kudos to @mbiarnes for spotting this! 🚀 

