### PR TITLE
BXMSPROD-1669: added new git-hub-action for checking URLs of web page

### DIFF
--- a/.github/workflows/check-url.yml
+++ b/.github/workflows/check-url.yml
@@ -1,0 +1,27 @@
+name: Check-URL
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: urls-checker
+        uses: urlstechie/urlchecker-action@0.2.31
+        with:
+          subfolder: data
+          file_types: .yml
+          print_all: false
+          timeout: 5
+          retry_count: 3
+          force_pass : true


### PR DESCRIPTION
**JIRA**: [BXMSPROD-1669](https://issues.redhat.com/browse/BXMSPROD-1669) 

Right after a release the versions have to be upgraded. In drools, jbpm and optaplanner the links in the web-page pointing to binaries to download from https://filemgmgt-prod.jboss.org/ are upgraded and have to be tested if they work.