### PR TITLE
DROOLS-7113 When Drools 8 published, update links on website

### DIFF
--- a/data/pom.yml
+++ b/data/pom.yml
@@ -1,4 +1,4 @@
-droolsDescription: Drools Expert is the rule engine and Drools Fusion does complex event processing (CEP).  Distribution zip contains binaries, examples, sources and javadocs.
+droolsZipDescription: Distribution zip contains binaries, examples, sources and javadocs.
 
 businessCentralDescription: Business Central Workbench is the web application and repository to govern Drools and jBPM assets. See <a href="../learn/documentation.html">documentation</a> for details about installation.
 
@@ -11,6 +11,22 @@ kieExecutionServerDescription: Standalone execution server that can be used to r
 kieWarsDescription: WAR files for all supported containers
 
 latestFinal:
+    version: 8.28.0.Beta
+    releaseDate: 2022-10-10
+
+    droolsZip: https://download.jboss.org/drools/release/8.28.0.Beta/drools-distribution-8.28.0.Beta.zip
+
+    documentationHtmlSingle: https://docs.drools.org/8.28.0.Beta/drools-docs/docs-website/drools
+    KIE_API_documentationJavadoc: https://docs.drools.org/8.28.0.Beta/kie-api-javadoc/index.html
+
+    droolsWhatsNew: https://docs.drools.org/8.28.0.Beta/drools-docs/docs-website/drools/release-notes/index.html
+    droolsReleaseNotes: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=12313021&version=12341351
+
+    droolsSnapZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.drools&a=drools-distribution&v=8.29.0-SNAPSHOT&e=zip
+
+# separating 7.x stream below
+
+latest7Final:
     version: 7.73.0.Final
     releaseDate: 2022-07-22
 
@@ -48,7 +64,7 @@ latestFinal:
     # updatesiteSnapZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.drools&a=org.drools.updatesite&v=7.74.0-SNAPSHOT&e=zip
 
 # latest.version can be equal to latestFinal.version
-latest:
+latest7:
     version: 7.73.0.Final
     releaseDate: 2022-07-22
 

--- a/data/pom.yml
+++ b/data/pom.yml
@@ -11,15 +11,15 @@ kieExecutionServerDescription: Standalone execution server that can be used to r
 kieWarsDescription: WAR files for all supported containers
 
 latestFinal:
-    version: 8.28.0.Beta
-    releaseDate: 2022-10-10
+    version: 8.29.0.Final
+    releaseDate: 2022-10-12
 
-    droolsZip: https://download.jboss.org/drools/release/8.28.0.Beta/drools-distribution-8.28.0.Beta.zip
+    droolsZip: https://download.jboss.org/drools/release/8.29.0.Final/drools-distribution-8.29.0.Final.zip
 
-    documentationHtmlSingle: https://docs.drools.org/8.28.0.Beta/drools-docs/docs-website/drools
-    KIE_API_documentationJavadoc: https://docs.drools.org/8.28.0.Beta/kie-api-javadoc/index.html
+    documentationHtmlSingle: https://docs.drools.org/8.29.0.Final/drools-docs/docs-website/drools
+    KIE_API_documentationJavadoc: https://docs.drools.org/8.29.0.Final/kie-api-javadoc/index.html
 
-    droolsWhatsNew: https://docs.drools.org/8.28.0.Beta/drools-docs/docs-website/drools/release-notes/index.html
+    droolsWhatsNew: https://docs.drools.org/8.29.0.Final/drools-docs/docs-website/drools/release-notes/index.html
     droolsReleaseNotes: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=12313021&version=12341351
 
     droolsSnapZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.drools&a=drools-distribution&v=8.29.0-SNAPSHOT&e=zip

--- a/templates/_content_download_download.ftl
+++ b/templates/_content_download_download.ftl
@@ -23,6 +23,11 @@
                             <p><a href="${pom.latestFinal.droolsReleaseNotes}">Release Notes</a></p>
                         </li>
                         <li>
+                            <p>The latest Drools releases, including ${pom.latestFinal.version} are available in the <a
+                                        href="http://search.maven.org/#search|ga|1|org.drools">Maven Central
+                                    Repository</a>.</p>
+                        </li>
+                        <li>
                             <p>License: <a href="../code/license.html">Apache License 2.0</a></p>
                         </li>
                     </ul>
@@ -44,10 +49,57 @@
                     <tr>
                         <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Drools
                                     Engine</strong></p></td>
-                        <td class="tableblock halign-left valign-top"><p class="tableblock">${pom.droolsDescription}</p>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">${pom.droolsZipDescription}</p>
                         </td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock"><a
                                 href="${pom.latestFinal.droolsZip}">Distribution ZIP</a></p></td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <br/>
+        <div class="sect1">
+            <h2 id="_latest_7_x_version_pom_latest7_version">Latest 7.x version: ${pom.latest7Final.version}</h2>
+            <div class="sectionbody">
+                <div class="ulist">
+                    <ul>
+                        <li>
+                            <p>Release date: <code>${pom.latest7Final.releaseDate?date}</code></p>
+                        </li>
+                        <li>
+                            <p><a href="${pom.latest7Final.droolsWhatsNew}">New and Noteworthy in
+                                drools ${pom.latest7Final.version}</a></p>
+                        </li>
+                        <li>
+                            <p><a href="${pom.latest7Final.droolsReleaseNotes}">Release Notes</a></p>
+                        </li>
+                        <li>
+                            <p>License: <a href="../code/license.html">Apache License 2.0</a></p>
+                        </li>
+                    </ul>
+                </div>
+                <table class="tableblock frame-ends grid-all stretch">
+                    <colgroup>
+                        <col style="width: 21.4285%;">
+                        <col style="width: 50%;">
+                        <col style="width: 28.5715%;">
+                    </colgroup>
+                    <thead>
+                    <tr>
+                        <th class="tableblock halign-left valign-top">Name</th>
+                        <th class="tableblock halign-left valign-top">Description</th>
+                        <th class="tableblock halign-left valign-top">Download</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Drools
+                                    Engine</strong></p></td>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">${pom.droolsZipDescription}</p>
+                        </td>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock"><a
+                                href="${pom.latest7Final.droolsZip}">Distribution ZIP</a></p></td>
                     </tr>
                     <tr>
                         <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Drools and jBPM
@@ -55,7 +107,7 @@
                         <td class="tableblock halign-left valign-top"><p
                                     class="tableblock">${pom.droolsjbpmIntegrationDescription}</p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock"><a
-                                href="${pom.latestFinal.droolsjbpmIntegrationZip}">Distribution ZIP</a></p>
+                                href="${pom.latest7Final.droolsjbpmIntegrationZip}">Distribution ZIP</a></p>
                         </td>
                     </tr>
                     <tr>
@@ -64,7 +116,7 @@
                         <td class="tableblock halign-left valign-top"><p
                                     class="tableblock">${pom.businessCentralDescription}</p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock"><a
-                                href="${pom.latestFinal.businessCentralWildFlyWAR}">WildFly 23 WAR</a></p></td>
+                                href="${pom.latest7Final.businessCentralWildFlyWAR}">WildFly 23 WAR</a></p></td>
                     </tr>
                     <tr>
                         <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>KIE Execution
@@ -72,7 +124,7 @@
                         <td class="tableblock halign-left valign-top"><p
                                     class="tableblock">${pom.kieExecutionServerDescription}</p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock"><a
-                                href="${pom.latestFinal.kieExecutionServerZip}">Distribution ZIP</a></p></td>
+                                href="${pom.latest7Final.kieExecutionServerZip}">Distribution ZIP</a></p></td>
                     </tr>
                     <tr>
                         <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>KIE Server
@@ -80,12 +132,13 @@
                         <td class="tableblock halign-left valign-top"><p
                                     class="tableblock">${pom.kieWarsDescription}</p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock"><a
-                                href="${pom.latestFinal.kieWARS}">ee7, ee8, webc WAR</a></p></td>
+                                href="${pom.latest7Final.kieWARS}">ee7, ee8, webc WAR</a></p></td>
                     </tr>
                     </tbody>
                 </table>
             </div>
         </div>
+        <br/>
         <div class="sect1">
             <h2 id="_latest_6_x_version_pom_latest6_version">Latest 6.x version: ${pom.latest6.version}</h2>
             <div class="sectionbody">
@@ -119,7 +172,7 @@
                     <tr>
                         <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Drools
                                     Engine</strong></p></td>
-                        <td class="tableblock halign-left valign-top"><p class="tableblock">${pom.droolsDescription}</p>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">Drools Expert is the rule engine and Drools Fusion does complex event processing (CEP). ${pom.droolsZipDescription}</p>
                         </td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock"><a
                                 href="${pom.latest6.droolsZip}">Distribution ZIP</a></p></td>
@@ -172,6 +225,10 @@
                     </tr>
                     </tbody>
                 </table>
+            </div>
+        </div>
+        <br/>
+        <div class="sect1">
                 <div class="sect2">
                     <h3 id="_other_downloads">Other downloads:</h3>
                     <div class="ulist">
@@ -290,7 +347,6 @@
                         </ul>
                     </div>
                 </div>
-            </div>
         </div>
     </@parent.layout>
 </#macro>

--- a/templates/_content_download_snapshots.ftl
+++ b/templates/_content_download_snapshots.ftl
@@ -30,50 +30,55 @@
                             ZIP</a></p></td>
                     </tr>
                     <tr>
-                        <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Jbpm distribution</strong></p>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>7.x stream:</strong></p>
+                        </td>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock"> </p></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Jbpm distribution (7.x stream)</strong></p>
                         </td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock"><a
-                                href="${pom.latestFinal.jbpmSnapZip}">Jbpm-distribution-bin
+                                href="${pom.latest7Final.jbpmSnapZip}">Jbpm-distribution-bin
                             ZIP</a></p></td>
                     </tr>
                     <tr>
-                        <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Business Central WAR</strong>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Business Central WAR (7.x stream)</strong>
                         </p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock"><a
-                                href="${pom.latestFinal.businessCentralSnapWF}">Wildfly
+                                href="${pom.latest7Final.businessCentralSnapWF}">Wildfly
                             19 WAR</a></p></td>
                     </tr>
                     <tr>
-                        <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>kie server ee7</strong></p></td>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>kie server ee7 (7.x stream)</strong></p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock"><a
-                                href="${pom.latestFinal.kieserverSnapEe7}">ee7
+                                href="${pom.latest7Final.kieserverSnapEe7}">ee7
                             WAR</a></p></td>
                     </tr>
                     <tr>
-                        <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>kie server ee8</strong></p></td>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>kie server ee8 (7.x stream)</strong></p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock"><a
-                                href="${pom.latestFinal.kieserverSnapEe8}">ee8
+                                href="${pom.latest7Final.kieserverSnapEe8}">ee8
                             WAR</a></p></td>
                     </tr>
                     <tr>
-                        <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>kie server webc</strong></p>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>kie server webc (7.x stream)</strong></p>
                         </td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock"><a
-                                href="${pom.latestFinal.kieserverSnapWebc}">webc
+                                href="${pom.latest7Final.kieserverSnapWebc}">webc
                             WAR</a></p></td>
                     </tr>
                     <tr>
-                        <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>kie server distribution</strong>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>kie server distribution (7.x stream)<</strong>
                         </p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock"><a
-                                href="${pom.latestFinal.kieserverSnapDistZip}">Distribution
+                                href="${pom.latest7Final.kieserverSnapDistZip}">Distribution
                             ZIP</a></p></td>
                     </tr>
                     <tr>
-                        <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>kie tomcat integration</strong>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>kie tomcat integration (7.x stream)<</strong>
                         </p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock"><a
-                                href="${pom.latestFinal.tomcatIntergrationSnap}">Tomcat
+                                href="${pom.latest7Final.tomcatIntergrationSnap}">Tomcat
                             integration JAR</a></p></td>
                     </tr>
                     </tbody>

--- a/templates/_content_download_snapshots.ftl
+++ b/templates/_content_download_snapshots.ftl
@@ -68,14 +68,14 @@
                             WAR</a></p></td>
                     </tr>
                     <tr>
-                        <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>kie server distribution (7.x stream)<</strong>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>kie server distribution (7.x stream)</strong>
                         </p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock"><a
                                 href="${pom.latest7Final.kieserverSnapDistZip}">Distribution
                             ZIP</a></p></td>
                     </tr>
                     <tr>
-                        <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>kie tomcat integration (7.x stream)<</strong>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>kie tomcat integration (7.x stream)</strong>
                         </p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock"><a
                                 href="${pom.latest7Final.tomcatIntergrationSnap}">Tomcat

--- a/templates/_content_learn_documentation.ftl
+++ b/templates/_content_learn_documentation.ftl
@@ -33,6 +33,36 @@
                         </li>
                     </ul>
                 </div>
+                <hr>
+            </div>
+        </div>
+        <div class="sect1">
+            <h2 id="_latest_7_x_releases">Latest 7.x releases</h2>
+            <div class="sectionbody">
+                <div class="ulist">
+                    <ul>
+                        <li>
+                            <p><strong>Documentation for Drools ${pom.latest7Final.version}</strong></p>
+                            <div class="ulist">
+                                <ul>
+                                    <li>
+                                        <p><span class="image"><img src="documentation.png" alt="documentation"></span>
+                                            <strong>Reference manual Drools ${pom.latest7Final.version}</strong>:
+                                            <a href="${pom.latest7Final.documentationHtmlSingle}">HTML Single</a></p>
+                                    </li>
+                                    <li>
+                                        <p>Kie API (Drools, jBPM) ${pom.latest7Final.version}:
+                                            <a href="${pom.latest7Final.KIE_API_documentationJavadoc}">Javadoc</a></p>
+                                    </li>
+                                    <li>
+                                        <p>Drools DMN engine, DMN FEEL handbook:
+                                            <a href="https://kiegroup.github.io/dmn-feel-handbook">HTML Single</a></p>
+                                    </li>
+                                </ul>
+                            </div>
+                        </li>
+                    </ul>
+                </div>
                 <div class="ulist">
                     <ul>
                         <li>
@@ -42,7 +72,7 @@
                                     <li>
                                         <p><span class="image"><img src="documentation.png" alt="documentation"></span>
                                             <strong>User Guide 7.46.0.Final</strong>:
-                                            <a href="${pom.latestFinal.userGuidePDF}">PDF</a></p>
+                                            <a href="${pom.latest7Final.userGuidePDF}">PDF</a></p>
                                     </li>
                                 </ul>
                             </div>
@@ -81,7 +111,7 @@
             </div>
         </div>
         <div class="sect1">
-            <h2 id="_drools_6_x_books">Drools 6.x Books</h2>
+            <h2 id="_books">Books</h2>
             <div class="sectionbody">
                 <div class="paragraph">
                     <p><a href="https://www.packtpub.com/networking-and-servers/mastering-jboss-drools-6"><span
@@ -89,9 +119,6 @@
                                                        alt="Mastering JBOSS Drools 6"></span></a></p>
                 </div>
             </div>
-        </div>
-        <div class="sect1">
-            <h2 id="_drools_5_x_books">Drools 5.x Books</h2>
             <div class="sectionbody">
                 <div class="paragraph">
                     <p><a href="http://www.packtpub.com/jboss-drools-business-rules/book"><span class="image"><img

--- a/templates/_content_learn_documentation.ftl
+++ b/templates/_content_learn_documentation.ftl
@@ -18,7 +18,7 @@
                                     <li>
                                         <p><span class="image"><img src="documentation.png" alt="documentation"></span>
                                             <strong>Reference manual Drools ${pom.latestFinal.version}</strong>:
-                                            <a href="${pom.latestFinal.documentationHtmlSingle}">HTML Single</a></p>
+                                            <a href="${pom.latestFinal.documentationHtmlSingle}">Drools documentation and User Guide</a></p>
                                     </li>
                                     <li>
                                         <p>Kie API (Drools, jBPM) ${pom.latestFinal.version}:

--- a/templates/index.ftl
+++ b/templates/index.ftl
@@ -12,16 +12,9 @@
     googleWebmasterToolsVerification=true>
         <div class="alert alert-info alert-dismissible" role="alert" id="release-version-alert">
             <i class="fas fa-info-circle"></i>
-            Reassuring news about Drools, KIE and “Log4Shell” CVE-2021-44228; full details <a class="alert-link" href="https://blog.kie.org/2021/12/kie-log4j2-exploit-cve-2021-44228.html">in this blog post</a>.
-            <button class="btn-close" data-bs-dismiss="alert" type="button" aria-label="Close"></button>
-        </div>
-        <div class="alert alert-info alert-dismissible" role="alert" id="release-version-alert">
-            <i class="fas fa-info-circle"></i>
-            <!-- 2021-08-05: -->
-            <!-- %a.alert-link(href="https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=12313021&version=12359307")Drools 7.58.0.Final has been released. -->
-            ${pom.latest.releaseDate?date?string.iso}:
+            ${pom.latestFinal.releaseDate?date?string.iso}:
             <a class="alert-link"
-            href="${pom.latest.droolsReleaseNotes}">Drools ${pom.latestFinal.version} has been released.</a>
+            href="${pom.latestFinal.droolsReleaseNotes}">Drools ${pom.latestFinal.version} has been released.</a>
             <button class="btn-close" data-bs-dismiss="alert" type="button" aria-label="Close"></button>
         </div>
         <div class="row">

--- a/templates/macros.ftl
+++ b/templates/macros.ftl
@@ -6,7 +6,7 @@
 <#macro latestReleases>
     <div class="card border-0">
         <div class="card-body">
-            <#if pom.latest.version == pom.latestFinal.version>
+            <#if !(pom.latest??) || pom.latest.version == pom.latestFinal.version>
                 <a class="btn btn-lg btn-success w-100"
                    href="${content.rootpath}download/download.html">
                     <img alt="Download" src="/download/download.png">
@@ -16,7 +16,7 @@
                     </div>
                 </a>
             </#if>
-            <#if pom.latest.version != pom.latestFinal.version>
+            <#if (pom.latest??) && pom.latest.version != pom.latestFinal.version>
                 <a class="btn btn-lg btn-success w-100"
                    href="${content.rootpath}download/download.html">
                     <img alt="Download" src="/download/download.png">

--- a/templates/shared/footer.ftl
+++ b/templates/shared/footer.ftl
@@ -29,7 +29,7 @@
                     <li><a class="link-light" href="${config.issueTracker}">Submit a bug</a></li>
                     <li><a class="link-light" href="https://access.redhat.com/security/team/contact/">Report a security issue</a></li>
                     <li><a class="link-light" href="${content.rootpath}code/license.html">License (Apache-2.0)</a></li>
-                    <li><a class="link-light" href="${pom.latest.droolsReleaseNotes}">Release notes</a></li>
+                    <li><a class="link-light" href="${pom.latestFinal.droolsReleaseNotes}">Release notes</a></li>
                     <li><a class="link-light" href="${content.rootpath}download/upgradeRecipe/">Upgrade recipes</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
https://issues.redhat.com/browse/DROOLS-7113

Raising as draft PR, so when artifacts are published and available, we just need to update in `pom.yaml`,
from: `8.28.0.Beta`
to: `8.29.0.Final`

Some preview of highlighted changes (if you notice anything unrelated to DROOLS-7113, please track it as separate JIRA):

![image](https://user-images.githubusercontent.com/1699252/194846119-8c9e0642-afb9-46a0-aaf6-3c26548e16e1.png)

![image](https://user-images.githubusercontent.com/1699252/194846147-52933575-81f1-4bea-8f66-a1011cea90f2.png)

![image](https://user-images.githubusercontent.com/1699252/194846182-802cecf9-4ec1-4d31-930f-80f985689e98.png)

![image](https://user-images.githubusercontent.com/1699252/194846469-82627cae-9323-4071-937a-4722adcbc8ea.png)
