### PR TITLE
KOGITO-8216 Migrate Drools publish job

### DIFF
--- a/.ci/jenkins/Jenkinsfile.publish
+++ b/.ci/jenkins/Jenkinsfile.publish
@@ -1,24 +1,24 @@
 @Library('jenkins-pipeline-shared-libraries')_
+
 import org.kie.jenkins.MavenCommand
 
-AGENT_LABEL="kie-rhel7 && kie-mem4g"
-MVN_TOOL="kie-maven-3.8.1"
-JDK_TOOL="kie-jdk11"
-REPO="drools-website"
-ORGANIZATION="kiegroup"
-BASE_BRANCH="main"
-MAIL_RECIPIENT="drools.b52addfd644a28664f16083dfe6e9453.show-sender@streams.zulipchat.com"
+droolsWebsiteRepo = 'drools-website'
 
 pipeline {
     agent {
-        label "$AGENT_LABEL"
+        label 'kie-rhel7 && kie-mem4g'
     }
-    options{
+    options {
         timestamps()
+        timeout(time: 1, unit: 'HOURS')
+        disableConcurrentBuilds(abortPrevious: true)
     }
     tools {
-        maven "$MVN_TOOL"
-        jdk "$JDK_TOOL"
+        maven env.BUILD_MAVEN_TOOL
+        jdk env.BUILD_JDK_TOOL
+    }
+    environment {
+        KOGITO_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
     }
     stages {
         stage('CleanWorkspace') {
@@ -33,10 +33,10 @@ pipeline {
                 }
             }
         }
-        stage('build drools-website'){
-            steps{
+        stage('build drools-website') {
+            steps {
                 script {
-                    dir("${REPO}"){
+                    dir("${droolsWebsiteRepo}") {
                         MavenCommand mvnCmd = new MavenCommand(this, ['-fae'])
                             .withSettingsXmlId('kogito_release_settings')
                         mvnCmd.run('clean package')
@@ -44,18 +44,18 @@ pipeline {
                 }
             }
         }
-        stage('zip drools-website'){
-            steps{
-                dir("${REPO}"){
-                    sh "tar -cvzf drools-website.tar -C target/website/ ."
-                    archiveArtifacts "drools-website.tar"
+        stage('zip drools-website') {
+            steps {
+                dir("${droolsWebsiteRepo}") {
+                    sh 'tar -cvzf drools-website.tar -C target/website/ .'
+                    archiveArtifacts 'drools-website.tar'
                 }
             }
         }
         stage('publish drools-website to filemgmt-prod-sync.jboss.org') {
             steps {
-                dir("${REPO}") {
-                    sshagent(["drools-filemgmt"]) {
+                dir("${droolsWebsiteRepo}") {
+                    sshagent(['drools-filemgmt']) {
                         sh './scripts/rsync_website.sh'
                     }
                 }
@@ -64,7 +64,7 @@ pipeline {
     }
     post {
         failure {
-            emailext to: "${MAIL_RECIPIENT}",
+            emailext to: "${KOGITO_CI_EMAIL_TO}",
             subject: 'status of drools-website automatic publishing',
             body: ' The status of Jenkins CI job for automatic publishing of the drools-website #${BUILD_NUMBER} was: FAILURE \n' +
             'because of ${BUILD_URL}consoleText \n' +
@@ -72,13 +72,13 @@ pipeline {
             cleanWs()
         }
         fixed {
-            emailext to: "${MAIL_RECIPIENT}",
+            emailext to: "${KOGITO_CI_EMAIL_TO}",
             subject: 'status of drools-website automatic publishing',
             body: 'The Jenkins CI job of automatic publishing of the drools-website #${BUILD_NUMBER} was fixed'
             cleanWs()
         }
         success {
-            emailext to: "${MAIL_RECIPIENT}",
+            emailext to: "${KOGITO_CI_EMAIL_TO}",
             subject: 'status of drools-website automatic publishing',
             body: 'The status of Jenkins CI job for automatic publishing of the drools-website #${BUILD_NUMBER} was: SUCCESSFUL'
             cleanWs()
@@ -87,7 +87,7 @@ pipeline {
 }
 
 void checkoutStartdroolsWeb() {
-    dir(REPO) {
-        checkout(githubscm.resolveRepository(REPO, ORGANIZATION, BASE_BRANCH, false))
+    dir(droolsWebsiteRepo) {
+        checkout(githubscm.resolveRepository(droolsWebsiteRepo, env.GIT_AUTHOR, env.BUILD_BRANCH_NAME, false, env.GIT_AUTHOR_CREDENTIALS_ID))
     }
 }

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -1,0 +1,37 @@
+/*
+* This file is describing all the Jenkins jobs in the DSL format (see https://plugins.jenkins.io/job-dsl/)
+* needed by the Kogito pipelines.
+*
+* The main part of Jenkins job generation is defined into the https://github.com/kiegroup/kogito-pipelines repository.
+*
+* This file is making use of shared libraries defined in
+* https://github.com/kiegroup/kogito-pipelines/tree/main/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl.
+*/
+
+import org.kie.jenkins.jobdsl.model.Folder
+import org.kie.jenkins.jobdsl.KogitoJobTemplate
+import org.kie.jenkins.jobdsl.KogitoJobUtils
+import org.kie.jenkins.jobdsl.Utils
+
+jenkins_path = '.ci/jenkins'
+
+if (Utils.isMainBranch(this)){
+    setupWebsitePublishOtherJob()
+}
+
+///////////////////////////////////////////////////////////////////////////
+
+void setupWebsitePublishOtherJob() {
+    def jobParams = KogitoJobUtils.getBasicJobParams(this, "drools-website-publish", Folder.OTHER, "${jenkins_path}/Jenkinsfile.publish",
+            "This is a pipeline job for publishing automatically the Drools Website.")
+    KogitoJobUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
+    jobParams.triggers = [ push: true ]
+    jobParams.env.putAll([
+            JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
+
+            BUILD_BRANCH_NAME: Utils.getGitBranch(this),
+            GIT_AUTHOR: Utils.getGitAuthor(this),
+            GIT_AUTHOR_CREDENTIALS_ID: Utils.getGitAuthorCredsId(this),
+    ])
+    KogitoJobTemplate.createPipelineJob(this, jobParams)
+}

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 /*.ipr
 /*.iws
 /*.iml
+.project
+.classpath
 
 # Repository wide ignore mac DS_Store files
 .DS_Store


### PR DESCRIPTION
To the Kogito DSL framework where all Drools Jenkins jobs are already

**NOTE:** Emails will now be published to `kogito-ci` like other Drools notifications

https://issues.redhat.com/browse/KOGITO-8216

Related:
- https://github.com/kiegroup/kogito-pipelines/pull/687
- https://github.com/kiegroup/drools-website/pull/230
- https://github.com/kiegroup/kie-jenkins-scripts/pull/1362