### PR TITLE
avoid 403 on wrong dl link

### DIFF
--- a/content/download/index.html
+++ b/content/download/index.html
@@ -1,0 +1,23 @@
+priority=0.0
+type=normalBase
+description=This page is not from the menu
+~~~~~~
+<h1>Are you looking to download Drools?</h1>
+<p>
+  You can download Drools from the <a href="/download/download.html">download</a> page.
+</p>
+<p>
+  You have reached a page which is not from the top menu,
+  you might consider starting from the 
+  <a href="/download/download.html">download</a>,
+  and navigate using the top menu from there.
+</p>
+<p>
+  If you have navigated here from another website, search result, other resource,
+  or you believe there is an issue with our website,
+  <a href="/community/getHelp.html">please let us know</a>
+  (including the URL which led you here) and we'll fix it.
+</p>
+<p>
+  <a href="/">Return to the website</a>.
+</p>


### PR DESCRIPTION
Avoid a 403 on linking from external sites to https://www.drools.org/download which is not from the classic menu

![image](https://github.com/kiegroup/drools-website/assets/1699252/557de5df-3670-4ae2-a3cf-856ae7312b50)
