### PR TITLE
Update `kiegroup` repository references to `apache`

### DIFF
--- a/.ci/jenkins/Jenkinsfile.publish
+++ b/.ci/jenkins/Jenkinsfile.publish
@@ -2,7 +2,7 @@
 
 import org.kie.jenkins.MavenCommand
 
-droolsWebsiteRepo = 'drools-website'
+droolsWebsiteRepo = 'incubator-drools-website'
 
 pipeline {
     agent {

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -2,10 +2,10 @@
 * This file is describing all the Jenkins jobs in the DSL format (see https://plugins.jenkins.io/job-dsl/)
 * needed by the Kogito pipelines.
 *
-* The main part of Jenkins job generation is defined into the https://github.com/apache/kogito-pipelines repository.
+* The main part of Jenkins job generation is defined into the https://github.com/apache/incubator-kie-kogito-pipelines repository.
 *
 * This file is making use of shared libraries defined in
-* https://github.com/apache/kogito-pipelines/tree/main/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl.
+* https://github.com/apache/incubator-kie-kogito-pipelines/tree/main/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl.
 */
 
 import org.kie.jenkins.jobdsl.model.JobType

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -2,10 +2,10 @@
 * This file is describing all the Jenkins jobs in the DSL format (see https://plugins.jenkins.io/job-dsl/)
 * needed by the Kogito pipelines.
 *
-* The main part of Jenkins job generation is defined into the https://github.com/kiegroup/kogito-pipelines repository.
+* The main part of Jenkins job generation is defined into the https://github.com/apache/kogito-pipelines repository.
 *
 * This file is making use of shared libraries defined in
-* https://github.com/kiegroup/kogito-pipelines/tree/main/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl.
+* https://github.com/apache/kogito-pipelines/tree/main/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl.
 */
 
 import org.kie.jenkins.jobdsl.model.JobType

--- a/.ci/jenkins/dsl/test.sh
+++ b/.ci/jenkins/dsl/test.sh
@@ -22,13 +22,13 @@ fi
 
 git_author="$(echo ${git_url} | awk -F"${git_server_url}" '{print $2}' | awk -F. '{print $1}'  | awk -F/ '{print $1}')"
 
-export DSL_DEFAULT_MAIN_CONFIG_FILE_REPO="${git_author}"/drools
-export DSL_DEFAULT_FALLBACK_MAIN_CONFIG_FILE_REPO=apache/drools
+export DSL_DEFAULT_MAIN_CONFIG_FILE_REPO="${git_author}"/incubator-kie-drools
+export DSL_DEFAULT_FALLBACK_MAIN_CONFIG_FILE_REPO=apache/incubator-kie-drools
 export DSL_DEFAULT_MAIN_CONFIG_FILE_PATH=.ci/jenkins/config/main.yaml
-export DSL_DEFAULT_BRANCH_CONFIG_FILE_REPO="${git_author}"/drools
+export DSL_DEFAULT_BRANCH_CONFIG_FILE_REPO="${git_author}"/incubator-kie-drools
 
 file=$(mktemp)
 # For more usage of the script, use ./test.sh -h
-curl -o ${file} https://raw.githubusercontent.com/apache/kogito-pipelines/main/dsl/seed/scripts/seed_test.sh
+curl -o ${file} https://raw.githubusercontent.com/apache/incubator-kie-kogito-pipelines/main/dsl/seed/scripts/seed_test.sh
 chmod u+x ${file}
 ${file} $@

--- a/.ci/jenkins/dsl/test.sh
+++ b/.ci/jenkins/dsl/test.sh
@@ -23,12 +23,12 @@ fi
 git_author="$(echo ${git_url} | awk -F"${git_server_url}" '{print $2}' | awk -F. '{print $1}'  | awk -F/ '{print $1}')"
 
 export DSL_DEFAULT_MAIN_CONFIG_FILE_REPO="${git_author}"/drools
-export DSL_DEFAULT_FALLBACK_MAIN_CONFIG_FILE_REPO=kiegroup/drools
+export DSL_DEFAULT_FALLBACK_MAIN_CONFIG_FILE_REPO=apache/drools
 export DSL_DEFAULT_MAIN_CONFIG_FILE_PATH=.ci/jenkins/config/main.yaml
 export DSL_DEFAULT_BRANCH_CONFIG_FILE_REPO="${git_author}"/drools
 
 file=$(mktemp)
 # For more usage of the script, use ./test.sh -h
-curl -o ${file} https://raw.githubusercontent.com/kiegroup/kogito-pipelines/main/dsl/seed/scripts/seed_test.sh
+curl -o ${file} https://raw.githubusercontent.com/apache/kogito-pipelines/main/dsl/seed/scripts/seed_test.sh
 chmod u+x ${file}
 ${file} $@

--- a/.github/workflows/jenkins-tests-PR.yml
+++ b/.github/workflows/jenkins-tests-PR.yml
@@ -18,6 +18,6 @@ jobs:
       uses: kiegroup/kie-ci/.ci/actions/dsl-tests@main
       with:
         project: drools
-        main-config-file-repo: apache/drools
+        main-config-file-repo: apache/incubator-kie-drools
         main-config-file-path: .ci/jenkins/config/main.yaml
-        branch-config-file-repo: apache/drools
+        branch-config-file-repo: apache/incubator-kie-drools

--- a/.github/workflows/jenkins-tests-PR.yml
+++ b/.github/workflows/jenkins-tests-PR.yml
@@ -18,6 +18,6 @@ jobs:
       uses: kiegroup/kie-ci/.ci/actions/dsl-tests@main
       with:
         project: drools
-        main-config-file-repo: kiegroup/drools
+        main-config-file-repo: apache/drools
         main-config-file-path: .ci/jenkins/config/main.yaml
-        branch-config-file-repo: kiegroup/drools
+        branch-config-file-repo: apache/drools


### PR DESCRIPTION
- https://github.com/kiegroup/kogito-pipelines/pull/1078
- https://github.com/kiegroup/kogito-runtimes/pull/3223
- https://github.com/kiegroup/kogito-examples/pull/1806
- https://github.com/kiegroup/kogito-apps/pull/1877
- https://github.com/kiegroup/kogito-images/pull/1698
- https://github.com/kiegroup/kogito-operator/pull/1528
- https://github.com/kiegroup/kogito-serverless-operator/pull/250
- https://github.com/kiegroup/kogito-docs/pull/497
- https://github.com/kiegroup/drools/pull/5519
- https://github.com/kiegroup/drools-website/pull/269
- https://github.com/radtriste/kie-benchmarks/pull/1 (WARNING: on `radtriste`, not on `kiegroup !`)
- https://github.com/asf-transfer/optaplanner/pull/2968
- https://github.com/kiegroup/optaplanner-quickstarts/pull/601