### PR TITLE
Fix GitHub star count

### DIFF
--- a/jbake.properties
+++ b/jbake.properties
@@ -32,7 +32,7 @@ title=Drools
 keywords=rule engine\\, business rule\\, java\\, DMN\\, decision model notation\\, open source\\, forward chain\\, backward chain\\, inference\\, decision table\\, DSL\\, software\\, library\\, constraint programming
 canonicalBaseUrl=https://drools.org
 issueTracker=https://issues.redhat.com/projects/DROOLS
-github=https://github.com/kiegroup/drools
+github=https://github.com/apache/incubator-kie-drools
 twitter=https://twitter.com/DroolsRules
 
 active_menu=drools


### PR DESCRIPTION
Address only:
- GitHub stargazers count
- "Fork me on GitHub" banner

which is derived from `config.github` for JBake generation

Currently:
![Screenshot 2023-10-28 at 15 38 50](https://github.com/kiegroup/drools-website/assets/1699252/e3cefbcd-9718-4cac-9467-1fa8cdfe26df)

Preview with this changes:
![Screenshot 2023-10-28 at 15 42 34](https://github.com/kiegroup/drools-website/assets/1699252/22589c0c-8ca6-49be-9986-c83cf2e0fb57)
