### PR TITLE
Update version and simplify Maven setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
       <plugin>
         <groupId>org.jbake</groupId>
         <artifactId>jbake-maven-plugin</artifactId>
-        <version>0.3.6-rc.2</version>
+        <version>2.7.0-rc.7</version>
         <executions>
           <execution>
             <phase>generate-resources</phase>
@@ -48,28 +48,6 @@
           <inputDirectory>${project.basedir}</inputDirectory>
           <outputDirectory>${project.build.directory}/website</outputDirectory>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.jbake</groupId>
-            <artifactId>jbake-core</artifactId>
-            <version>2.7.0-rc.4</version>
-          </dependency>
-          <dependency>
-            <groupId>org.asciidoctor</groupId>
-            <artifactId>asciidoctorj</artifactId>
-            <version>2.5.2</version>
-          </dependency>
-          <dependency>
-            <groupId>org.freemarker</groupId>
-            <artifactId>freemarker</artifactId>
-            <version>2.3.31</version>
-          </dependency>
-          <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>2.0</version>
-          </dependency>
-        </dependencies>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
1. version bumps resolve platform incompatibilities on non-x86 platforms
```
[ERROR] Failed to execute goal org.jbake:jbake-maven-plugin:0.3.6-rc.2:generate (default) on project drools-website: Execution default of goal org.jbake:jbake-maven-plugin:0.3.6-rc.2:generate failed: An API incompatibility was encountered while executing org.jbake:jbake-maven-plugin:0.3.6-rc.2:generate: java.lang.UnsatisfiedLinkError: ... (fat file, but missing compatible architecture (have 'i386,x86_64', need 'arm64'))
```
see also: https://github.com/jbake-org/jbake/pull/765

2. avoid the need to specify manually jbake-maven-plugin dependencies version
ref: https://github.com/jbake-org/jbake/pull/740#:~:text=The%20Maven%20and%20Gradle%20versions%20should%20use%20the%20same%20asciidoc%2C%20markdown%2C%20freemarker%2C%20etc%20versions%20as%20jbake%2Dcore